### PR TITLE
Forced Matplotlib to use Qt4Agg interface to prevent conflict with Qt5

### DIFF
--- a/LabControle2.py
+++ b/LabControle2.py
@@ -7,6 +7,9 @@ Created on Tue Apr 01 15:24:20 2014
 
 from PyQt4 import QtCore,QtGui, QtSvg
 
+import matplotlib
+matplotlib.use("Qt4Agg")
+
 from matplotlib.backends.backend_qt4 import NavigationToolbar2QT as NavigationToolbar
 
 import MainWindow


### PR DESCRIPTION
I faced conflict while using this software on my computer because Matplotlib was trying to use Qt5 implementation, while the app uses Qt4. So I added a line to force Matplotlib to use the Qt4 interface. 