### PR TITLE
Feature/Block analysis actions when there is an error in input fields

### DIFF
--- a/LabControle2.py
+++ b/LabControle2.py
@@ -729,6 +729,9 @@ class LabControle2(QtWidgets.QMainWindow,MainWindow.Ui_MainWindow):
         """
         Plot LGR graphic.
         """
+        if self._has_expressions_errors():
+            return
+
         self.statusBar().showMessage(_translate("MainWindow", "Plotando LGR...", None))
         
         # Plot LGR:
@@ -849,6 +852,9 @@ class LabControle2(QtWidgets.QMainWindow,MainWindow.Ui_MainWindow):
         """
         Plot nyquist diagram Button handler
         """
+        if self._has_expressions_errors():
+            return
+
         self.statusBar().showMessage(_translate("MainWindow", "Traçando Nyquist...", None))
         
         self.sys.Nyquist(self.mplNyquist.figure,completo=self.checkBoxNyqNegFreq.isChecked(),comcirculo=self.checkBoxNyqCirc.isChecked())
@@ -892,7 +898,10 @@ class LabControle2(QtWidgets.QMainWindow,MainWindow.Ui_MainWindow):
    
     
     def onBtnPlotBode(self):
-        
+
+        if self._has_expressions_errors():
+            return
+
         self.statusBar().showMessage(_translate("MainWindow", "Traçando Bode...", None))
         
         # Plotting Bode:

--- a/MainWindow.py
+++ b/MainWindow.py
@@ -1646,7 +1646,7 @@ class Ui_MainWindow(object):
 
     def retranslateUi(self, MainWindow):
         _translate = QtCore.QCoreApplication.translate
-        MainWindow.setWindowTitle(_translate("MainWindow", "LabControle 2.3 - Beta 1"))
+        MainWindow.setWindowTitle(_translate("MainWindow", "LabControle 2.3 - #develop"))
         self.groupBoxRt.setToolTip(_translate("MainWindow", "Parâmetros da entrada de referência"))
         self.groupBoxRt.setTitle(_translate("MainWindow", "Entrada: r(t)"))
         self.labelRvalue.setText(_translate("MainWindow", "Valor:"))

--- a/MainWindow.py
+++ b/MainWindow.py
@@ -1646,7 +1646,8 @@ class Ui_MainWindow(object):
 
     def retranslateUi(self, MainWindow):
         _translate = QtCore.QCoreApplication.translate
-        MainWindow.setWindowTitle(_translate("MainWindow", "LabControle 2.3 - #develop"))
+        # MainWindow.setWindowTitle(_translate("MainWindow", "LabControle 2.3 - #develop"))
+        MainWindow.setWindowTitle(_translate("MainWindow", "LabControle 2.3 - Beta 1"))
         self.groupBoxRt.setToolTip(_translate("MainWindow", "Parâmetros da entrada de referência"))
         self.groupBoxRt.setTitle(_translate("MainWindow", "Entrada: r(t)"))
         self.labelRvalue.setText(_translate("MainWindow", "Valor:"))


### PR DESCRIPTION
Implementing feature #29.

If the expression has errors, but is not active (*checked*), when that is an option, analysis won't be blocked.

Also, translate is missing.