### PR TITLE
Add macos (darwing) calculator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ __pycache__
 /*.LCN
 /*.LCO
 /LabControle2.1b2_x64.zip
+/.venv/

--- a/LabControl3.py
+++ b/LabControl3.py
@@ -2548,6 +2548,11 @@ class LabControl3(QtWidgets.QMainWindow):#,MainWindow.Ui_MainWindow):
                 p=subprocess.Popen('gnome-calculator')
             except FileNotFoundError:
                 QtWidgets.QMessageBox.critical(self,_translate("MainWindow", "Erro!", None),_translate("MainWindow", "Executável da calculadora não encontrado (gnome-calculator).", None))
+        elif system == 'Darwin':
+            try:
+                p=subprocess.Popen(['open', '-a', 'Calculator'])
+            except OSError:
+                QtWidgets.QMessageBox.critical(self,_translate("MainWindow", "Erro!", None),_translate("MainWindow", "Executável da calculadora não encontrado (Calculator).", None))
         else:
             QtWidgets.QMessageBox.critical(self,_translate("MainWindow", "Erro!", None),_translate("MainWindow", "Não foi possível determinar o sistema operacional.", None))
     


### PR DESCRIPTION
The program doesn't show any calculator if you tap calc button on `macos`.

![image](https://github.com/user-attachments/assets/c8102f28-30e8-47eb-a6ec-4d2fcaaeea8c)


This change allows the program to properly open the system calculator when it runs on `macos`. 
![image](https://github.com/user-attachments/assets/d7aa1438-59f1-4554-afd6-79739a135458)
